### PR TITLE
Update arm-none-eabi-gcc-action to v1.10.1 to fix v3 cache issue.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: arm-none-eabi-gcc GNU Arm Embedded Toolchain
-      uses: carlosperate/arm-none-eabi-gcc-action@v1.10.0
+      uses: carlosperate/arm-none-eabi-gcc-action@v1.10.1
     - name: Checkout pico-sdk/2.1.1
       uses: actions/checkout@v4.1.1
       with:


### PR DESCRIPTION
see https://github.com/orgs/community/discussions/160793 for more info on v3 caching being disabled. this arm-none-eabi-gcc-action version lets the caching in the action work properly again. 